### PR TITLE
Make output file names unique

### DIFF
--- a/tubetube/helpers.py
+++ b/tubetube/helpers.py
@@ -1,5 +1,7 @@
+import os
 import re
 import yt_dlp
+from datetime import datetime
 
 
 def parse_video_id(url):
@@ -14,6 +16,19 @@ def parse_video_id(url):
         if match:
             return match.group(1)
     return None
+
+# Generate a unique filename using timestamp
+def create_unique_file(dir_name,file_name):
+    full_path = os.path.join(dir_name, file_name)
+    if not os.path.exists(full_path):
+        return file_name
+    # Get current timestamp in seconds since epoch
+    timestamp = str(datetime.timestamp(datetime.now()))
+    
+    # Create a filename with base name and timestamp
+    unique_file_name = f"{file_name}_{timestamp}"
+    
+    return unique_file_name
 
 
 class TrimDescriptionPP(yt_dlp.postprocessor.PostProcessor):

--- a/tubetube/helpers.py
+++ b/tubetube/helpers.py
@@ -1,7 +1,5 @@
-import os
 import re
 import yt_dlp
-from datetime import datetime
 
 
 def parse_video_id(url):
@@ -16,19 +14,6 @@ def parse_video_id(url):
         if match:
             return match.group(1)
     return None
-
-# Generate a unique filename using timestamp
-def create_unique_file(dir_name,file_name):
-    full_path = os.path.join(dir_name, file_name)
-    if not os.path.exists(full_path):
-        return file_name
-    # Get current timestamp in seconds since epoch
-    timestamp = str(datetime.timestamp(datetime.now()))
-    
-    # Create a filename with base name and timestamp
-    unique_file_name = f"{file_name}_{timestamp}"
-    
-    return unique_file_name
 
 
 class TrimDescriptionPP(yt_dlp.postprocessor.PostProcessor):

--- a/tubetube/yt_downloader.py
+++ b/tubetube/yt_downloader.py
@@ -211,7 +211,7 @@ class DownloadManager:
         ydl_opts = {
             "ignore_no_formats_error": True,
             "noplaylist": True,
-            "outtmpl": f"{item_title}_%(upload_date)s.%(ext)s",
+            "outtmpl": f"{item_title}_%(timestamp)s.%(ext)s",
             "progress_hooks": [lambda d: self._progress_hook(d, download_id)],
             "ffmpeg_location": self.ffmpeg_location,
             "writethumbnail": True,

--- a/tubetube/yt_downloader.py
+++ b/tubetube/yt_downloader.py
@@ -206,13 +206,12 @@ class DownloadManager:
             download_format = f"{video_format_id}+{audio_format_id}/bestvideo+bestaudio/best"
 
         item_title = re.sub(r'[<>:"/\\|?*]', "-", item.get("title"))
-        item_title = helpers.create_unique_file(item_title)
         final_path = f"/data/{folder_name}"
 
         ydl_opts = {
             "ignore_no_formats_error": True,
             "noplaylist": True,
-            "outtmpl": f"{item_title}.%(ext)s",
+            "outtmpl": f"{item_title}_%(upload_date)s.%(ext)s",
             "progress_hooks": [lambda d: self._progress_hook(d, download_id)],
             "ffmpeg_location": self.ffmpeg_location,
             "writethumbnail": True,

--- a/tubetube/yt_downloader.py
+++ b/tubetube/yt_downloader.py
@@ -206,6 +206,7 @@ class DownloadManager:
             download_format = f"{video_format_id}+{audio_format_id}/bestvideo+bestaudio/best"
 
         item_title = re.sub(r'[<>:"/\\|?*]', "-", item.get("title"))
+        item_title = helpers.create_unique_file(item_title)
         final_path = f"/data/{folder_name}"
 
         ydl_opts = {


### PR DESCRIPTION
When multiple videos have the same title, output files are overridden.
I used the timestamp tag and added it as part as the output template to make sure each video gets a unique file name.